### PR TITLE
Improved module resolution

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -203,9 +203,11 @@ export class PackherdModuleLoader {
       if (moduleCached != null) {
         const fullPath = moduleKey
         const resolved = 'module-key:node'
+        const origin = 'Module._cache'
+        this._updateCaches(moduleCached, resolved, origin, moduleKey)
         return {
           resolved,
-          origin: 'Module._cache',
+          origin,
           exports: moduleCached.exports,
           fullPath,
         }
@@ -224,9 +226,11 @@ export class PackherdModuleLoader {
       const moduleCached = this.Module._cache[fullPath]
       if (moduleCached != null) {
         const resolved = 'module-fullpath:node'
+        const origin = 'Module._cache'
+        this._updateCaches(moduleCached, resolved, origin, moduleKey)
         return {
           resolved,
-          origin: 'Module._cache',
+          origin,
           exports: moduleCached.exports,
           fullPath,
         }
@@ -242,11 +246,12 @@ export class PackherdModuleLoader {
     )
     if (loadedModule != null) {
       this._dumpInfo()
-      assert(
-        fullPath != null,
-        'Should have full path when cache-direct loading succeeded'
+      this._updateCaches(
+        loadedModule.mod,
+        loadedModule.resolved,
+        loadedModule.origin,
+        moduleKey
       )
-      this.Module._cache[fullPath] = loadedModule.mod
       return loadedModule
     }
 
@@ -279,6 +284,21 @@ export class PackherdModuleLoader {
     }
   }
 
+  private _updateCaches(
+    mod: NodeModule,
+    resolved: string,
+    origin: string,
+    moduleKey: string | undefined
+  ) {
+    assert(
+      mod.id != null,
+      `Should have module id when loading by ${resolved} via ${origin} succeeded`
+    )
+    this.Module._cache[mod.id] = mod
+    if (moduleKey != null) {
+      this.moduleExports[moduleKey] = mod
+    }
+  }
   private _resolvePaths(
     moduleUri: string,
     parent: NodeModule,

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -39,7 +39,7 @@ class LoadingModules {
   private readonly currentlyLoading: Map<string, Module> = new Map()
   start(id: string, mod: Module) {
     if (this.currentlyLoading.has(id)) {
-      throw new Error(`Already loading ${id}`)
+      throw new Error(`Already loading ${id}\nstack: ${this.stack()}`)
     }
     this.currentlyLoading.set(id, mod)
   }
@@ -361,9 +361,9 @@ export class PackherdModuleLoader {
   ) {
     const origin: ModuleLoadResult['origin'] = 'packherd:definition'
     const mod: NodeModule = this._createModule(fullPath, parent, moduleUri)
-    this.loading.start(moduleKey, mod)
 
     try {
+      this.loading.start(moduleKey, mod)
       moduleDefinition(
         mod.exports,
         mod,

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -268,6 +268,27 @@ export class PackherdModuleLoader {
       directFullPath
     ))
 
+    // 8. Something like './foo' might now have been resolved to './foo.js' and
+    // thus we may find it inside our cache that way
+    const derivedModuleKey = `./${path.relative(this.projectBaseDir, fullPath)}`
+    loadedModule = this._loadCacheDirect(
+      moduleUri,
+      derivedModuleKey,
+      fullPath,
+      parent
+    )
+    if (loadedModule != null) {
+      this._dumpInfo()
+      loadedModule.resolved = 'cache:node'
+      this._updateCaches(
+        loadedModule.mod,
+        loadedModule.resolved,
+        loadedModule.origin,
+        moduleKey
+      )
+      return loadedModule
+    }
+
     const exports = this.origLoad(fullPath, parent, isMain)
     this.misses++
     this._dumpInfo()

--- a/src/require.ts
+++ b/src/require.ts
@@ -106,7 +106,7 @@ export function packherdRequire(
     parent: typeof Module,
     isMain: boolean
   ) {
-    logTrace('_load "%s"', moduleUri)
+    logTrace('Module._load "%s"', moduleUri)
     if (Module.builtinModules.includes(moduleUri)) {
       return origLoad(moduleUri, parent, isMain)
     }
@@ -116,7 +116,7 @@ export function packherdRequire(
         origin,
         exports,
         fullPath,
-        relPath,
+        moduleRelativePath,
       } = moduleLoader.tryLoad(moduleUri, parent, isMain)
 
       switch (resolved) {
@@ -125,7 +125,7 @@ export function packherdRequire(
             'Resolved "%s" via %s (%s | %s)',
             moduleUri,
             resolved,
-            relPath,
+            moduleRelativePath,
             fullPath
           )
           break
@@ -135,7 +135,7 @@ export function packherdRequire(
             'Resolved "%s" via %s (%s | %s)',
             moduleUri,
             resolved,
-            relPath,
+            moduleRelativePath,
             fullPath
           )
           break
@@ -148,7 +148,7 @@ export function packherdRequire(
             'Loaded "%s" via %s resolved as (%s | %s)',
             moduleUri,
             origin,
-            relPath,
+            moduleRelativePath,
             fullPath
           )
           break
@@ -156,15 +156,15 @@ export function packherdRequire(
         case 'packherd:export':
         case 'packherd:definition':
         case 'packherd:loading': {
-          logTrace('Loaded "%s" via %s', moduleUri, origin)
+          logTrace('Loaded "%s" via (%s | %s)', moduleUri, origin, resolved)
           break
         }
       }
 
       return exports
     } catch (err) {
-      logError(err)
       if (diagnostics && !moduleUri.endsWith('hook-require')) {
+        logError(err)
         debugger
       }
     }

--- a/src/require.ts
+++ b/src/require.ts
@@ -123,7 +123,8 @@ export function packherdRequire(
         case 'module:node':
         case 'module-uri:node':
         case 'module-fullpath:node':
-        case 'module-key:node': {
+        case 'module-key:node':
+        case 'cache:node': {
           logTrace(
             'Resolved "%s" via %s (%s | %s)',
             moduleUri,

--- a/src/require.ts
+++ b/src/require.ts
@@ -4,6 +4,7 @@ import { DefaultTranspileCache } from './default-transpile-cache'
 import { ModuleLoaderOpts, PackherdModuleLoader } from './loader'
 import { installSourcemapSupport } from './sourcemap-support'
 import type { PackherdTranspileOpts, SourceMapLookup } from './types'
+import path from 'path'
 
 const logInfo = debug('packherd:info')
 const logDebug = debug('packherd:debug')
@@ -111,16 +112,18 @@ export function packherdRequire(
       return origLoad(moduleUri, parent, isMain)
     }
     try {
-      const {
-        resolved,
-        origin,
-        exports,
-        fullPath,
-        moduleRelativePath,
-      } = moduleLoader.tryLoad(moduleUri, parent, isMain)
+      const { resolved, origin, exports, fullPath } = moduleLoader.tryLoad(
+        moduleUri,
+        parent,
+        isMain
+      )
+      const moduleRelativePath = path.relative(projectBaseDir, fullPath)
 
       switch (resolved) {
-        case 'module:node': {
+        case 'module:node':
+        case 'module-uri:node':
+        case 'module-fullpath:node':
+        case 'module-key:node': {
           logTrace(
             'Resolved "%s" via %s (%s | %s)',
             moduleUri,

--- a/src/sourcemap-support.ts
+++ b/src/sourcemap-support.ts
@@ -11,6 +11,7 @@ import convertSourceMap from 'convert-source-map'
 import { DefaultTranspileCache } from './default-transpile-cache'
 
 const logError = debug('packherd:error')
+const logDebug = debug('packherd:debug')
 const logTrace = debug('packherd:trace')
 
 const INCLUDE_CODE_BEFORE = 2
@@ -130,6 +131,7 @@ export function installSourcemapSupport(
     sourceMapLookup
   )
   if (Error.prepareStackTrace === sourcemapSupport.prepareStackTrace) return
+  logDebug('Installing sourcemap')
 
   Error.prepareStackTrace = sourcemapSupport.prepareStackTrace
 }
@@ -166,8 +168,10 @@ class SourcemapSupport {
         // Keep trying to include some code until we succeeded once
         includeCodeFrames = c.codeFrames.length === 0
       }
-      for (const codeFrame of c.codeFrames.reverse()) {
-        processedStack.push(`\n      ${codeFrame}`)
+      if (c.codeFrames != null) {
+        for (const codeFrame of c.codeFrames.reverse()) {
+          processedStack.push(`\n      ${codeFrame}`)
+        }
       }
       processedStack.push('\n    at ' + c)
       state.nextPos = state.curPos

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ export type ModuleResolveResult = {
     | 'module:tsc'
     | 'path'
     | 'cache:direct'
+    | 'cache:node'
   fullPath: string
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,9 +19,9 @@ export type ModuleDefinition = (
 ) => NodeModule
 
 export type ModuleResolveResult = {
-  resolved: 'module:node' | 'module:tsc' | 'path'
+  resolved: 'module:node' | 'module:tsc' | 'path' | 'cache:direct'
   fullPath: string
-  relPath: string
+  moduleRelativePath: string
 }
 
 export type ModuleLoadResult = ModuleResolveResult & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,9 +19,15 @@ export type ModuleDefinition = (
 ) => NodeModule
 
 export type ModuleResolveResult = {
-  resolved: 'module:node' | 'module:tsc' | 'path' | 'cache:direct'
+  resolved:
+    | 'module:node'
+    | 'module-uri:node'
+    | 'module-fullpath:node'
+    | 'module-key:node'
+    | 'module:tsc'
+    | 'path'
+    | 'cache:direct'
   fullPath: string
-  moduleRelativePath: string
 }
 
 export type ModuleLoadResult = ModuleResolveResult & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,7 +31,7 @@ export type ModuleResolveResult = {
 }
 
 export type ModuleLoadResult = ModuleResolveResult & {
-  exports: NodeModule
+  exports: NodeModule['exports']
   origin:
     | 'packherd:export'
     | 'packherd:definition'

--- a/tests/fixtures/circular-deps/definitions.js
+++ b/tests/fixtures/circular-deps/definitions.js
@@ -22,7 +22,7 @@ function entry(exports, module, __filename, __dirname, require) {
 }
 
 module.exports = {
-  'foo.js': foo,
-  'bar.js': bar,
-  'entry.js': entry,
+  './foo.js': foo,
+  './bar.js': bar,
+  './entry.js': entry,
 }

--- a/tests/fixtures/circular-deps/hook-require.js
+++ b/tests/fixtures/circular-deps/hook-require.js
@@ -6,9 +6,16 @@ const entryFile = require.resolve('./lib/entry')
 
 const logDebug = debug('packherd:debug')
 
-function getModuleKey(moduleRelativePath, moduleUri) {
-  logDebug({ moduleRelativePath, moduleUri })
-  return moduleUri
+function getModuleKey({ moduleUri, baseDir }) {
+  const moduleRelativePath = path.isAbsolute(moduleUri)
+    ? path.relative(baseDir, moduleUri)
+    : moduleUri
+
+  logDebug({ baseDir, moduleUri, moduleRelativePath })
+  return {
+    moduleKey: moduleUri,
+    moduleRelativePath,
+  }
 }
 
 const projectBaseDir = path.dirname(entryFile)


### PR DESCRIPTION
Trying as much as possible to avoid I/O by resolving module URIs via a resolver map that is provided.
Therefore we fall back to Node.js resolve mechanism only when all else fails. Additionally we try to use the Node.js module cache as well as snapshot caches to avoid loading the module from disk as much as possible.

The update of those caches has been improved as well.
As an aside a minor sourcemap fix was applied as well.

- resolver: cache:direct resolving cached modules
- resolver: cache:direct resolving module definitions
- resolver: further optimized module resolution
- resolver: updating Module._cache with resolved modules
- resolution: updating caches when module resolved
- resolution: fix circular resolution handling
- sourcemap: no longer crashing when no codeFrames from `wrapCallSite`
- resolution: fall back to direct fullPath for tricky modules
- resolution: try cache again after Node.js resolve
- resolution: fix circular definition loading
