### PR TITLE
feat/module cache

### DIFF
--- a/src/loader.ts
+++ b/src/loader.ts
@@ -141,6 +141,11 @@ export class PackherdModuleLoader {
   definitionHits: Set<string> = new Set()
   misses: Set<string> = new Set()
   private readonly diagnostics: boolean
+  private _dumpedInfo: {
+    exportHits: number
+    definitionHits: number
+    misses: number
+  }
   private readonly getModuleKey: GetModuleKey
   private readonly moduleExports: Record<string, Module>
   private readonly moduleDefinitions: Record<string, ModuleDefinition>
@@ -155,6 +160,7 @@ export class PackherdModuleLoader {
     opts: ModuleLoaderOpts
   ) {
     this.diagnostics = !!opts.diagnostics
+    this._dumpedInfo = { exportHits: 0, definitionHits: 0, misses: 0 }
     this.getModuleKey = opts.getModuleKey || defaultGetModuleKey
     assert(
       opts.moduleExports != null || opts.moduleDefinitions != null,
@@ -484,12 +490,28 @@ export class PackherdModuleLoader {
   }
 
   private _dumpInfo() {
-    if (this.diagnostics) {
-      logDebug({
-        exportHits: this.exportHits.size,
-        definitionHits: this.definitionHits.size,
-        misses: this.misses.size,
-      })
+    if (this.diagnostics && logDebug.enabled) {
+      const {
+        exportHits: prevExportHits,
+        definitionHits: prevDefinitionHits,
+        misses: prevMisses,
+      } = this._dumpedInfo
+
+      const exportHits = this.exportHits.size
+      const definitionHits = this.definitionHits.size
+      const misses = this.misses.size
+      if (
+        prevExportHits !== exportHits ||
+        prevDefinitionHits !== definitionHits ||
+        prevMisses !== misses
+      ) {
+        this._dumpedInfo = {
+          exportHits,
+          definitionHits,
+          misses,
+        }
+        logDebug(this._dumpedInfo)
+      }
     }
   }
 

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -306,6 +306,9 @@ export class PackherdModuleLoader {
     }
 
     // 4. Lastly try to resolve the module via Node.js resolution
+    if (opts != null) {
+      this._ensureParentPaths(opts)
+    }
     assert(
       opts != null && (opts as NodeModule).id != null,
       'Need a parent to resolve via Node.js'
@@ -498,6 +501,9 @@ export class PackherdModuleLoader {
       parent,
       isMain
     )
+    if (fullPath == null) {
+      debugger
+    }
     assert(fullPath != null, `packherd: unresolvable module ${moduleUri}`)
     return { resolved, fullPath }
   }
@@ -691,7 +697,7 @@ export class PackherdModuleLoader {
     }
   }
 
-  private _ensureParentPaths(parent: NodeModule) {
+  private _ensureParentPaths(parent: { path: string; paths?: string[] }) {
     if (
       parent.paths == null ||
       (parent.paths.length === 0 && parent.path != null)

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -6,7 +6,6 @@ import {
   ModuleDefinition,
   ModuleLoadResult,
   ModuleResolveResult,
-  ModuleMapper,
   ModuleNeedsReload,
 } from './types'
 import { Benchmark } from './benchmark'
@@ -38,7 +37,6 @@ export type ModuleLoaderOpts = {
   moduleDefinitions?: Record<string, ModuleDefinition>
   getModuleKey?: GetModuleKey
   moduleNeedsReload?: ModuleNeedsReload
-  moduleMapper?: ModuleMapper
 }
 
 const defaultGetModuleKey: GetModuleKey = ({ moduleUri, baseDir }) => {
@@ -129,14 +127,6 @@ class CacheTracker {
   }
 }
 
-function identity(
-  _mod: NodeModule,
-  moduleUri: string,
-  _projectBasedir: string
-) {
-  return moduleUri
-}
-
 function needsFullPathResolve(p: string) {
   return !path.isAbsolute(p) && p.startsWith('./')
 }
@@ -155,7 +145,6 @@ export class PackherdModuleLoader {
   private readonly moduleExports: Record<string, Module>
   private readonly moduleDefinitions: Record<string, ModuleDefinition>
   private readonly loading: LoadingModules
-  private readonly moduleMapper: ModuleMapper
   private readonly cacheTracker: CacheTracker
 
   constructor(
@@ -173,7 +162,6 @@ export class PackherdModuleLoader {
     )
     this.moduleExports = opts.moduleExports ?? {}
     this.moduleDefinitions = opts.moduleDefinitions ?? {}
-    this.moduleMapper = opts.moduleMapper ?? identity
     this.loading = new LoadingModules()
     this.cacheTracker = new CacheTracker(
       this.Module._cache,
@@ -507,14 +495,6 @@ export class PackherdModuleLoader {
     isMain: boolean,
     directFullPath?: string
   ): ModuleResolveResult {
-    if (1 + 1 !== 2) {
-      const mappedModuleUri = this.moduleMapper(
-        parent,
-        moduleUri,
-        this.projectBaseDir
-      )
-      console.log(mappedModuleUri)
-    }
     const resolved = 'module:node'
     const fullPath = this._tryResolveFilename(
       moduleUri,

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -636,8 +636,28 @@ export class PackherdModuleLoader {
           const res = this.Module._resolveFilename(fullPath, parent, isMain)
           return res
         } catch (err2) {
-          console.error(err2)
-          return undefined
+          // In some cases like native addons which aren't included in the esbuild bundle we need to try to resolve
+          // relative to the project base dir
+          try {
+            const basedOnProjectRoot = path.resolve(
+              this.projectBaseDir,
+              moduleUri
+            )
+            const res = this.Module._resolveFilename(
+              basedOnProjectRoot,
+              parent,
+              isMain
+            )
+            logTrace(
+              'Resolved "%s" based on project root to "%s"',
+              moduleUri,
+              basedOnProjectRoot
+            )
+            return res
+          } catch (err3) {
+            console.error(err3)
+            return undefined
+          }
         }
       }
     }

--- a/src/loader.ts
+++ b/src/loader.ts
@@ -366,7 +366,9 @@ export class PackherdModuleLoader {
     }
 
     // 4. Try to obtain a full path
-    this._ensureParentPaths(parent)
+    if (parent != null) {
+      this._ensureParentPaths(parent)
+    }
     let fullPath = this._tryResolveFullPath(
       moduleUri,
       moduleRelativePath,
@@ -520,7 +522,7 @@ export class PackherdModuleLoader {
       parent,
       path: fullPath,
       // TODO(thlorenz): not entirely correct if parent is nested deeper or higher
-      paths: parent?.paths || [],
+      paths: parent?.paths ?? [],
       require,
     }
   }
@@ -590,7 +592,7 @@ export class PackherdModuleLoader {
       {
         paths(request: string) {
           if (Module.builtinModules.includes(request)) return null
-          return parent?.paths || null
+          return parent?.paths ?? null
         },
       }
     )
@@ -658,13 +660,13 @@ export class PackherdModuleLoader {
 
   private _ensureFullPathExportsModule(mod: NodeModule) {
     if (mod.id == null) mod.id = mod.filename
-    if (needsFullPathResolve(mod.id)) {
+    if (mod.id != null && needsFullPathResolve(mod.id)) {
       mod.id = path.resolve(this.projectBaseDir, mod.id)
     }
-    if (needsFullPathResolve(mod.filename)) {
+    if (mod.filename != null && needsFullPathResolve(mod.filename)) {
       mod.filename = path.resolve(this.projectBaseDir, mod.filename)
     }
-    if (needsFullPathResolve(mod.path)) {
+    if (mod.path != null && needsFullPathResolve(mod.path)) {
       mod.path = path.resolve(this.projectBaseDir, mod.path)
     }
   }

--- a/src/require.ts
+++ b/src/require.ts
@@ -189,5 +189,6 @@ export function packherdRequire(
     },
     shouldBypassCache: moduleLoader.shouldBypassCache.bind(moduleLoader),
     registerModuleLoad: moduleLoader.registerModuleLoad.bind(moduleLoader),
+    tryLoad: moduleLoader.tryLoad.bind(moduleLoader),
   }
 }

--- a/src/require.ts
+++ b/src/require.ts
@@ -7,7 +7,11 @@ import {
   PackherdModuleLoader,
 } from './loader'
 import { installSourcemapSupport } from './sourcemap-support'
-import type { PackherdTranspileOpts, SourceMapLookup } from './types'
+import type {
+  ModuleNeedsReload,
+  PackherdTranspileOpts,
+  SourceMapLookup,
+} from './types'
 import path from 'path'
 
 const logInfo = debug('packherd:info')
@@ -20,6 +24,7 @@ export type PackherdRequireOpts = ModuleLoaderOpts & {
   requireStatsFile?: string
   transpileOpts?: Partial<PackherdTranspileOpts>
   sourceMapLookup?: SourceMapLookup
+  moduleNeedsReload?: ModuleNeedsReload
 }
 
 const DEFAULT_TRANSPILE_OPTS = {

--- a/src/require.ts
+++ b/src/require.ts
@@ -1,7 +1,11 @@
 import debug from 'debug'
 import { Benchmark, setupBenchmark } from './benchmark'
 import { DefaultTranspileCache } from './default-transpile-cache'
-import { ModuleLoaderOpts, PackherdModuleLoader } from './loader'
+import {
+  GetModuleKeyOpts,
+  ModuleLoaderOpts,
+  PackherdModuleLoader,
+} from './loader'
 import { installSourcemapSupport } from './sourcemap-support'
 import type { PackherdTranspileOpts, SourceMapLookup } from './types'
 import path from 'path'
@@ -174,5 +178,11 @@ export function packherdRequire(
     }
   }
 
-  return { resolve: moduleLoader.tryResolve.bind(moduleLoader) }
+  return {
+    resolve(uri: string, opts?: GetModuleKeyOpts) {
+      return moduleLoader.tryResolve(uri, opts).fullPath
+    },
+    shouldBypassCache: moduleLoader.shouldBypassCache.bind(moduleLoader),
+    registerModuleLoad: moduleLoader.registerModuleLoad.bind(moduleLoader),
+  }
 }

--- a/src/require.ts
+++ b/src/require.ts
@@ -157,7 +157,7 @@ export function packherdRequire(
 
       switch (origin) {
         case 'Module._load': {
-          logDebug(
+          logTrace(
             'Loaded "%s" via %s resolved as (%s | %s)',
             moduleUri,
             origin,

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,7 +47,7 @@ export type ModuleMapper = (
   projectBasedir: string
 ) => string
 
-export type ModuleBuildin = typeof import('module') & {
+export type ModuleBuiltin = typeof import('module') & {
   _resolveFilename(
     moduleUri: string,
     parent: NodeModule | undefined,

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,3 +115,12 @@ export type MapAndSourceContent = {
   map: SourceMapConsumer
   sourceContent: string
 }
+
+// -----------------
+// Module Resolution
+// -----------------
+export type ModuleNeedsReload = (
+  moduleId: string,
+  loadedModules: Set<string>,
+  moduleCache: Record<string, NodeModule>
+) => boolean


### PR DESCRIPTION
Improves `require` and `require.resolve` by handling more scenarios as well as making it stricter.
Fills in `parent` paths and in general behaves much closer to Node.js resolution mechanism.
Additionally hits/misses are counted more exact.

- require: adding module cache tracker
- require: hooks into cache update and cache bypass query
- require: respecting moduleNeedsReload function
- require: loader improvements related to module setup
- require: improved loader to fill in parent paths
- loader: more defensive when ensuring parent paths
- loader: resloving from project root as last resort
- loader: ensuring parent paths when for require.resolve
- loading: more correct hit/miss counting
- loader: removing module loader reference entirely
- loader: resolve replicating Node.js MODULE_NOT_FOUND behavior
- loading: require and require.resolve improvements
- loading: only printing diagnostics when numbers changed
- require: logging less on debug
